### PR TITLE
Update renv.Rmd

### DIFF
--- a/vignettes/renv.Rmd
+++ b/vignettes/renv.Rmd
@@ -41,7 +41,7 @@ knitr::include_graphics("renv.png", dpi = 144)
 ```
 
 We assume you're already living a project-centric lifestyle and are familiar with a version control system, like Git and GitHub: we believe these are table stakes for reproducible data science.
-If you're not already using projects, we recommend [Workflow: Projects](https://r4ds.had.co.nz/workflow-projects.html) from *R for Data Science*; if you're unfamiliar with [Git](https://git-scm.com/) and [GitHub](https://github.com/), we recommend [Happy Git and GitHub for the useR](https://happygitwithr.com).
+If you're not already using projects, we recommend [Workflow: scripts and projects](https://r4ds.hadley.nz/workflow-scripts.html) from *R for Data Science*; if you're unfamiliar with [Git](https://git-scm.com/) and [GitHub](https://github.com/), we recommend [Happy Git and GitHub for the useR](https://happygitwithr.com).
 
 ## Libraries and repositories
 


### PR DESCRIPTION
When you click on the Workflow: scripts and projects link, there is a notice at the page that directs you to the second edition.  So, I've updated the link in this vignette to point the reader directly to the second edition.